### PR TITLE
Fix trainer points double grant on restart

### DIFF
--- a/creature_battler_bot.py
+++ b/creature_battler_bot.py
@@ -369,7 +369,7 @@ async def _catch_up_trainer_points_now():
         SET trainer_points = t.trainer_points
           + ((5 + LEAST(GREATEST(t.facility_level - 1, 0), 5))
              * GREATEST(0, (SELECT d FROM today) - COALESCE(t.last_tp_grant, (SELECT d FROM today)))),
-            last_tp_grant = COALESCE(t.last_tp_grant, (SELECT d FROM today))
+            last_tp_grant = (SELECT d FROM today)
     """)
 
 @tasks.loop(hours=12)


### PR DESCRIPTION
## Summary
- ensure trainer-point catch-up updates `last_tp_grant`

## Testing
- `python -m py_compile creature_battler_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_689f1fba9a2c83289c832e6fa5ad1f3a