### PR TITLE
Remove redundant facility_level alteration

### DIFF
--- a/creature_battler_bot.py
+++ b/creature_battler_bot.py
@@ -116,8 +116,6 @@ ALTER TABLE creatures
 
 ALTER TABLE creatures
   ADD COLUMN IF NOT EXISTS personality JSONB;
-ALTER TABLE trainers
-  ADD COLUMN IF NOT EXISTS facility_level INT DEFAULT 1;
 
 -- store display names for leaderboards
 ALTER TABLE trainers


### PR DESCRIPTION
## Summary
- remove duplicated facility_level ALTER TABLE statement from schema

## Testing
- `python - <<'PY'
import asyncio
import creature_battler_bot as cbb
async def main():
    pool = await cbb.db_pool()
    async with pool.acquire() as conn:
        await conn.execute(cbb.SCHEMA_SQL)
asyncio.run(main())
PY` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a07b50253c8328a28a7e1ad0830a7d