### PR TITLE
Add interactive controls channel with buttons

### DIFF
--- a/creature_battler_bot.py
+++ b/creature_battler_bot.py
@@ -51,6 +51,8 @@ logger.info("Using TEXT_MODEL=%s, IMAGE_MODEL=%s", TEXT_MODEL, IMAGE_MODEL)
 LEADERBOARD_CHANNEL_ID_ENV = os.getenv("LEADERBOARD_CHANNEL_ID")
 # Optional: channel where the live creature shop is posted/updated.
 SHOP_CHANNEL_ID_ENV = os.getenv("SHOP_CHANNEL_ID")
+# Optional: channel where interactive controls are posted.
+CONTROLS_CHANNEL_ID_ENV = os.getenv("CONTROLS_CHANNEL_ID")
 
 # Admin allow-list for privileged commands (e.g., /cashadd, /setleaderboardchannel)
 def _parse_admin_ids(raw: Optional[str]) -> set[int]:
@@ -1714,8 +1716,23 @@ async def setup_hook():
 
 @bot.event
 async def on_ready():
+    global _controls_message_posted
     logger.info("Logged in as %s", bot.user)
     try:
+        # Register persistent view for controls
+        bot.add_view(controls_view)
+        if CONTROLS_CHANNEL_ID_ENV and not _controls_message_posted:
+            try:
+                chan_id = int(CONTROLS_CHANNEL_ID_ENV)
+                channel = bot.get_channel(chan_id) or await bot.fetch_channel(chan_id)
+                embed = discord.Embed(
+                    title="Controls",
+                    description="Use the buttons below to manage your trainer and creatures.",
+                )
+                await channel.send(embed=embed, view=controls_view)
+                _controls_message_posted = True
+            except Exception as e:
+                logger.error("Failed to post controls message: %s", e)
         # No global sync here; setup_hook already handled guild/global registration and cleanup.
         synced = []
         logger.info("Ready. (%d commands)", len(synced))
@@ -2209,8 +2226,8 @@ class ShopView(discord.ui.View):
     async def buy_button(self, interaction: discord.Interaction, button: discord.ui.Button):
         await interaction.response.send_modal(BuyModal())
 
-@bot.tree.command(description="Rename one of your creatures")
-async def rename(inter: discord.Interaction, creature_name: str, new_name: str):
+async def _rename_creature(inter: discord.Interaction, creature_name: str, new_name: str):
+    """Core logic for renaming a creature."""
     row = await ensure_registered(inter)
     if not row:
         return
@@ -2259,6 +2276,11 @@ async def rename(inter: discord.Interaction, creature_name: str, new_name: str):
     )
     asyncio.create_task(update_leaderboard_now(reason="rename"))
     asyncio.create_task(update_shop_now(reason="rename"))
+
+
+@bot.tree.command(description="Rename one of your creatures")
+async def rename(inter: discord.Interaction):
+    await inter.response.send_modal(RenameModal())
 
 @bot.tree.command(description="Show glyphs and tier progress for a creature")
 async def glyphs(inter: discord.Interaction, creature_name: str):
@@ -2777,8 +2799,8 @@ async def trainerpoints(inter: discord.Interaction):
             ephemeral=True
         )
 
-@bot.tree.command(description="Train a creature stat")
-async def train(inter: discord.Interaction, creature_name: str, stat: str, increase: int):
+async def _train_creature(inter: discord.Interaction, creature_name: str, stat: str, increase: int):
+    """Core logic for training a creature."""
     stat = stat.upper()
     if stat not in PRIMARY_STATS:
         return await inter.response.send_message(
@@ -2833,6 +2855,11 @@ async def train(inter: discord.Interaction, creature_name: str, stat: str, incre
         f"{c['id']} – {creature_name.title()} trained: +{display_inc} {stat}{' (x2 personality bonus)' if mult == 2 else ''}.",
         ephemeral=True
     )
+
+
+@bot.tree.command(description="Train a creature stat")
+async def train(inter: discord.Interaction):
+    await inter.response.send_modal(TrainModal())
 
 @bot.tree.command(description="Show and confirm upgrading your training facility")
 async def upgrade(inter: discord.Interaction):
@@ -2982,6 +3009,62 @@ async def enc(inter: discord.Interaction, creature_name: str):
         return await inter.followup.send("Failed to post to the Encyclopedia channel.", ephemeral=True)
 
     await inter.followup.send(f"Added **{name}** to the Encyclopedia: {msg.jump_url}", ephemeral=True)
+
+
+# ─── Interactive controls (modals & buttons) ──────────────────
+
+class RenameModal(discord.ui.Modal, title="Rename Creature"):
+    creature_name: discord.ui.TextInput = discord.ui.TextInput(label="Current Name")
+    new_name: discord.ui.TextInput = discord.ui.TextInput(label="New Name")
+
+    async def on_submit(self, interaction: discord.Interaction):
+        await _rename_creature(interaction, self.creature_name.value, self.new_name.value)
+
+
+class TrainModal(discord.ui.Modal, title="Train Creature"):
+    creature_name: discord.ui.TextInput = discord.ui.TextInput(label="Creature Name")
+    stat: discord.ui.TextInput = discord.ui.TextInput(label="Stat")
+    amount: discord.ui.TextInput = discord.ui.TextInput(label="Increase Amount")
+
+    async def on_submit(self, interaction: discord.Interaction):
+        try:
+            inc = int(self.amount.value)
+        except ValueError:
+            return await interaction.response.send_message("Amount must be an integer.", ephemeral=True)
+        await _train_creature(interaction, self.creature_name.value, self.stat.value, inc)
+
+
+class ControlsView(discord.ui.View):
+    def __init__(self):
+        super().__init__(timeout=None)
+
+    @discord.ui.button(label="Creatures", style=discord.ButtonStyle.secondary)
+    async def btn_creatures(self, interaction: discord.Interaction, button: discord.ui.Button):
+        await creatures(interaction)
+
+    @discord.ui.button(label="Trainer Points", style=discord.ButtonStyle.secondary)
+    async def btn_tp(self, interaction: discord.Interaction, button: discord.ui.Button):
+        await trainerpoints(interaction)
+
+    @discord.ui.button(label="Cash", style=discord.ButtonStyle.secondary)
+    async def btn_cash(self, interaction: discord.Interaction, button: discord.ui.Button):
+        await cash(interaction)
+
+    @discord.ui.button(label="Upgrade", style=discord.ButtonStyle.primary)
+    async def btn_upgrade(self, interaction: discord.Interaction, button: discord.ui.Button):
+        await upgrade(interaction)
+
+    @discord.ui.button(label="Train", style=discord.ButtonStyle.success)
+    async def btn_train(self, interaction: discord.Interaction, button: discord.ui.Button):
+        await interaction.response.send_modal(TrainModal())
+
+    @discord.ui.button(label="Rename", style=discord.ButtonStyle.success)
+    async def btn_rename(self, interaction: discord.Interaction, button: discord.ui.Button):
+        await interaction.response.send_modal(RenameModal())
+
+
+controls_view = ControlsView()
+_controls_message_posted = False
 
 @bot.tree.command(description="Show all commands and what they do")
 async def info(inter: discord.Interaction):


### PR DESCRIPTION
## Summary
- add optional controls channel for interactive gameplay
- replace `/train` and `/rename` with modals
- expose buttons to run key commands like creatures, trainer points, cash, upgrade, train and rename

## Testing
- `python -m py_compile creature_battler_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68a308ebca9c8328b264a71e00324a05