### PR TITLE
Delay ControlsView creation until event loop is running

### DIFF
--- a/creature_battler_bot.py
+++ b/creature_battler_bot.py
@@ -1387,6 +1387,10 @@ async def _get_or_create_controls_message(channel_id: int) -> Optional[discord.M
         logger.error("Failed to fetch controls channel %s: %s", channel_id, e)
         return None
 
+    global controls_view
+    if controls_view is None:
+        controls_view = ControlsView()
+
     pool = await db_pool()
     msg_id = await pool.fetchval(
         "SELECT message_id FROM controls_messages WHERE channel_id=$1",
@@ -3131,8 +3135,7 @@ class ControlsView(discord.ui.View):
     async def btn_rename(self, interaction: discord.Interaction, button: discord.ui.Button):
         await interaction.response.send_modal(RenameModal())
 
-
-controls_view = ControlsView()
+controls_view: Optional[ControlsView] = None
 
 @bot.tree.command(description="Show all commands and what they do")
 async def info(inter: discord.Interaction):


### PR DESCRIPTION
## Summary
- Lazily create `ControlsView` and store in global variable
- Initialize the view only when needed, avoiding "no running event loop" during import

## Testing
- `python -m py_compile creature_battler_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68a31584db288328b217b1338ac305e5