### PR TITLE
Limit PvP challenges to 50 OVR difference

### DIFF
--- a/creature_battler_bot.py
+++ b/creature_battler_bot.py
@@ -2640,15 +2640,14 @@ async def pvp(inter: discord.Interaction, creature_name: str, opponent: discord.
     )
     if not opp_creatures:
         return await inter.response.send_message("Opponent has no available creature.", ephemeral=True)
-    min_ovr = challenger_ovr * 0.8
-    max_ovr = challenger_ovr * 1.2
     opp_creatures = [
-        r for r in opp_creatures
-        if min_ovr <= sum(json.loads(r["stats"]).values()) <= max_ovr
+        r
+        for r in opp_creatures
+        if abs(sum(json.loads(r["stats"]).values()) - challenger_ovr) <= 50
     ]
     if not opp_creatures:
         return await inter.response.send_message(
-            "Opponent has no creature within 20% OVR of your creature.", ephemeral=True
+            "Opponent has no creature within 50 OVR of your creature.", ephemeral=True
         )
 
     options = [discord.SelectOption(label=r["name"], value=str(r["id"])) for r in opp_creatures]


### PR DESCRIPTION
## Summary
- Limit PvP opponent selection to creatures within 50 OVR of the challenger's creature

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a31e4a73c48328b880ae2d53a9ffee