### PR TITLE
Ensure controls view persists

### DIFF
--- a/creature_battler_bot.py
+++ b/creature_battler_bot.py
@@ -1412,6 +1412,11 @@ async def _get_or_create_controls_message(channel_id: int) -> Optional[discord.M
                 description="Use the buttons below to manage your trainer and creatures.",
             )
             message = await channel.send(embed=embed, view=controls_view)
+            # Explicitly register the persistent view so the buttons continue
+            # working even after the bot restarts. Without this, the message
+            # would remain but future interaction callbacks would fail with
+            # "This interaction failed" because the view was not re-bound.
+            bot.add_view(controls_view, message_id=message.id)
             await pool.execute(
                 """
                 INSERT INTO controls_messages(channel_id, message_id)


### PR DESCRIPTION
## Summary
- Register ControlsView with message ID after creating controls message so buttons keep working after restarts

## Testing
- `python -m py_compile creature_battler_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68a321ea0ac08328893632b528ea0b36