### PR TITLE
Add item descriptions and per-item buy buttons

### DIFF
--- a/creature_battler_bot.py
+++ b/creature_battler_bot.py
@@ -255,10 +255,13 @@ SELL_PRICES: Dict[str, int] = {
 
 SMALL_HEALING_INJECTOR = "Small Healing Injector"
 SMALL_HEALING_INJECTOR_PRICE = 26_000
+SMALL_HEALING_INJECTOR_DESC = "Heals a creature for 25% of its max HP."
 LARGE_HEALING_INJECTOR = "Large Healing Injector"
 LARGE_HEALING_INJECTOR_PRICE = 34_000
+LARGE_HEALING_INJECTOR_DESC = "Heals a creature for 50% of its max HP."
 FULL_HEALING_INJECTOR = "Full Healing Injector"
 FULL_HEALING_INJECTOR_PRICE = 45_000
+FULL_HEALING_INJECTOR_DESC = "Fully restores a creature's HP."
 
 def spawn_rarity() -> str:
     r = random.random() * 100.0
@@ -1634,17 +1637,17 @@ async def update_item_store_now(reason: str = "manual") -> None:
     )
     embed.add_field(
         name=SMALL_HEALING_INJECTOR,
-        value=f"Price: {SMALL_HEALING_INJECTOR_PRICE}",
+        value=f"{SMALL_HEALING_INJECTOR_DESC}\nPrice: {SMALL_HEALING_INJECTOR_PRICE}",
         inline=False,
     )
     embed.add_field(
         name=LARGE_HEALING_INJECTOR,
-        value=f"Price: {LARGE_HEALING_INJECTOR_PRICE}",
+        value=f"{LARGE_HEALING_INJECTOR_DESC}\nPrice: {LARGE_HEALING_INJECTOR_PRICE}",
         inline=False,
     )
     embed.add_field(
         name=FULL_HEALING_INJECTOR,
-        value=f"Price: {FULL_HEALING_INJECTOR_PRICE}",
+        value=f"{FULL_HEALING_INJECTOR_DESC}\nPrice: {FULL_HEALING_INJECTOR_PRICE}",
         inline=False,
     )
     try:
@@ -2473,21 +2476,11 @@ async def buy(inter: discord.Interaction, creature_name: str):
     asyncio.create_task(update_leaderboard_now(reason="buy"))
 
 
-async def _buy_item(inter: discord.Interaction, item_name: str, quantity: int):
+async def _buy_item(
+    inter: discord.Interaction, item_const: str, price: int, quantity: int
+):
     if quantity <= 0:
         return await inter.response.send_message("Quantity must be positive.", ephemeral=True)
-    item_key = item_name.strip().lower()
-    if item_key == SMALL_HEALING_INJECTOR.lower():
-        item_const = SMALL_HEALING_INJECTOR
-        price = SMALL_HEALING_INJECTOR_PRICE
-    elif item_key == LARGE_HEALING_INJECTOR.lower():
-        item_const = LARGE_HEALING_INJECTOR
-        price = LARGE_HEALING_INJECTOR_PRICE
-    elif item_key == FULL_HEALING_INJECTOR.lower():
-        item_const = FULL_HEALING_INJECTOR
-        price = FULL_HEALING_INJECTOR_PRICE
-    else:
-        return await inter.response.send_message("Unknown item.", ephemeral=True)
     row = await ensure_registered(inter)
     if not row:
         return
@@ -2557,25 +2550,43 @@ class ShopView(discord.ui.View):
         await interaction.response.send_modal(BuyModal())
 
 
-class BuyItemModal(discord.ui.Modal, title="Buy Item"):
-    item_name = discord.ui.TextInput(label="Item Name")
-    quantity = discord.ui.TextInput(label="Quantity")
+class BuyItemModal(discord.ui.Modal):
+    def __init__(self, item_const: str, price: int):
+        super().__init__(title=f"Buy {item_const}")
+        self.item_const = item_const
+        self.price = price
+        self.quantity: discord.ui.TextInput = discord.ui.TextInput(label="Quantity")
+        self.add_item(self.quantity)
 
     async def on_submit(self, interaction: discord.Interaction):
         try:
             qty = int(self.quantity.value)
         except ValueError:
             return await interaction.response.send_message("Quantity must be an integer.", ephemeral=True)
-        await _buy_item(interaction, self.item_name.value, qty)
+        await _buy_item(interaction, self.item_const, self.price, qty)
 
 
 class ItemStoreView(discord.ui.View):
     def __init__(self):
         super().__init__(timeout=None)
 
-    @discord.ui.button(label="Buy", style=discord.ButtonStyle.green)
-    async def buy_button(self, interaction: discord.Interaction, button: discord.ui.Button):
-        await interaction.response.send_modal(BuyItemModal())
+    @discord.ui.button(label=SMALL_HEALING_INJECTOR, style=discord.ButtonStyle.green)
+    async def buy_small(self, interaction: discord.Interaction, button: discord.ui.Button):
+        await interaction.response.send_modal(
+            BuyItemModal(SMALL_HEALING_INJECTOR, SMALL_HEALING_INJECTOR_PRICE)
+        )
+
+    @discord.ui.button(label=LARGE_HEALING_INJECTOR, style=discord.ButtonStyle.green)
+    async def buy_large(self, interaction: discord.Interaction, button: discord.ui.Button):
+        await interaction.response.send_modal(
+            BuyItemModal(LARGE_HEALING_INJECTOR, LARGE_HEALING_INJECTOR_PRICE)
+        )
+
+    @discord.ui.button(label=FULL_HEALING_INJECTOR, style=discord.ButtonStyle.green)
+    async def buy_full(self, interaction: discord.Interaction, button: discord.ui.Button):
+        await interaction.response.send_modal(
+            BuyItemModal(FULL_HEALING_INJECTOR, FULL_HEALING_INJECTOR_PRICE)
+        )
 
 async def _rename_creature(inter: discord.Interaction, creature_name: str, new_name: str):
     """Core logic for renaming a creature."""


### PR DESCRIPTION
## Summary
- add descriptive text for all store items
- replace single store buy button with individual item buttons
- simplify buying flow to require quantity only

## Testing
- `python -m py_compile creature_battler_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5bcee67108328ac2599a2524c3ccf