### PR TITLE
Align item store buy buttons with items

### DIFF
--- a/creature_battler_bot.py
+++ b/creature_battler_bot.py
@@ -1638,17 +1638,17 @@ async def update_item_store_now(reason: str = "manual") -> None:
     embed.add_field(
         name=SMALL_HEALING_INJECTOR,
         value=f"{SMALL_HEALING_INJECTOR_DESC}\nPrice: {SMALL_HEALING_INJECTOR_PRICE}",
-        inline=False,
+        inline=True,
     )
     embed.add_field(
         name=LARGE_HEALING_INJECTOR,
         value=f"{LARGE_HEALING_INJECTOR_DESC}\nPrice: {LARGE_HEALING_INJECTOR_PRICE}",
-        inline=False,
+        inline=True,
     )
     embed.add_field(
         name=FULL_HEALING_INJECTOR,
         value=f"{FULL_HEALING_INJECTOR_DESC}\nPrice: {FULL_HEALING_INJECTOR_PRICE}",
-        inline=False,
+        inline=True,
     )
     try:
         await message.edit(content=None, embed=embed, view=ItemStoreView())
@@ -2570,19 +2570,19 @@ class ItemStoreView(discord.ui.View):
     def __init__(self):
         super().__init__(timeout=None)
 
-    @discord.ui.button(label="Buy", style=discord.ButtonStyle.green, row=0)
+    @discord.ui.button(label="Buy Small", style=discord.ButtonStyle.green, row=0)
     async def buy_small(self, interaction: discord.Interaction, button: discord.ui.Button):
         await interaction.response.send_modal(
             BuyItemModal(SMALL_HEALING_INJECTOR, SMALL_HEALING_INJECTOR_PRICE)
         )
 
-    @discord.ui.button(label="Buy", style=discord.ButtonStyle.green, row=1)
+    @discord.ui.button(label="Buy Large", style=discord.ButtonStyle.green, row=0)
     async def buy_large(self, interaction: discord.Interaction, button: discord.ui.Button):
         await interaction.response.send_modal(
             BuyItemModal(LARGE_HEALING_INJECTOR, LARGE_HEALING_INJECTOR_PRICE)
         )
 
-    @discord.ui.button(label="Buy", style=discord.ButtonStyle.green, row=2)
+    @discord.ui.button(label="Buy Full", style=discord.ButtonStyle.green, row=0)
     async def buy_full(self, interaction: discord.Interaction, button: discord.ui.Button):
         await interaction.response.send_modal(
             BuyItemModal(FULL_HEALING_INJECTOR, FULL_HEALING_INJECTOR_PRICE)


### PR DESCRIPTION
## Summary
- Display item store fields inline so buy buttons can sit beneath their respective items
- Arrange buy buttons on the same row with item-specific labels for clarity

## Testing
- `python -m py_compile creature_battler_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5c1da75e08328af0f8ccee0246459