### PR TITLE
Remove daily cap from info text

### DIFF
--- a/creature_battler_bot.py
+++ b/creature_battler_bot.py
@@ -4957,9 +4957,7 @@ async def info(inter: discord.Interaction):
     caps_line = (
         "• Passive income: 60 cash/hour | Creature cap: "
         + str(MAX_CREATURES)
-        + " | Daily cap: "
-        + str(DAILY_BATTLE_CAP)
-        + "/creature/day (Europe/London)."
+        + "."
     )
     header = (
         "**Game Overview**\n"


### PR DESCRIPTION
## Summary
- remove daily battle cap mention from /info text for clarity

## Testing
- `python -m py_compile creature_battler_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68a9e66c75308328a2e8f6cd5a408a82