### PR TITLE
Fix upgrade interaction response

### DIFF
--- a/creature_battler_bot.py
+++ b/creature_battler_bot.py
@@ -4082,9 +4082,11 @@ async def _do_upgrade(inter: discord.Interaction):
     )
     new_bonus = FACILITY_LEVELS[next_level]["bonus"]
     await inter.response.send_message(
-        f"✅ Upgraded to **Level {next_level} – {FACILITY_LEVELS[next_level]['name']}**!\n",
-        f"Your facility now grants **+{new_bonus} trainer points/day** "
-        f"(total {daily_trainer_points_for(next_level)}/day).",
+        (
+            f"✅ Upgraded to **Level {next_level} – {FACILITY_LEVELS[next_level]['name']}**!\n"
+            f"Your facility now grants **+{new_bonus} trainer points/day** "
+            f"(total {daily_trainer_points_for(next_level)}/day)."
+        ),
         ephemeral=True,
     )
 


### PR DESCRIPTION
## Summary
- fix facility upgrade response failing due to incorrect `send_message` usage

## Testing
- `python -m py_compile creature_battler_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab03827a7c83288a660344d8b5e412