### PR TITLE
Increase creature generation timeout

### DIFF
--- a/creature_battler_bot.py
+++ b/creature_battler_bot.py
@@ -1023,7 +1023,7 @@ Avoid words: {', '.join(sorted(avoid_words)) if avoid_words else 'None'}
                     input=prompt,
                     max_output_tokens=MAX_OUTPUT_TOKENS,
                 )),
-                timeout=30.0
+                timeout=60.0
             )
             text = (getattr(resp, 'output_text', '') or '').strip()
             if not text:


### PR DESCRIPTION
## Summary
- double OpenAI creature-generation timeout to reduce `/spawn` failures

## Testing
- `python -m py_compile creature_battler_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68af0da723248328b45edf5fb28d416a