### PR TITLE
Scale token limit with batch size for spawn names

### DIFF
--- a/creature_battler_bot.py
+++ b/creature_battler_bot.py
@@ -1021,7 +1021,9 @@ Avoid words: {', '.join(sorted(avoid_words)) if avoid_words else 'None'}
                 _to_thread(lambda: client.responses.create(
                     model=TEXT_MODEL,
                     input=prompt,
-                    max_output_tokens=MAX_OUTPUT_TOKENS,
+                    # Generate multiple names/descriptors in a single request,
+                    # so scale the token allowance with the batch size.
+                    max_output_tokens=MAX_OUTPUT_TOKENS * count,
                 )),
                 timeout=60.0
             )


### PR DESCRIPTION
## Summary
- Scale OpenAI `max_output_tokens` by spawn batch size so multi-name requests have enough room

## Testing
- `python -m py_compile creature_battler_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68af12f68cfc83289b76f08193287887