### PR TITLE
Scale HP regeneration from total health

### DIFF
--- a/creature_battler_bot.py
+++ b/creature_battler_bot.py
@@ -674,13 +674,13 @@ async def regenerate_hp():
         UPDATE creatures c
         SET current_hp = LEAST(
                 COALESCE(c.current_hp, (c.stats->>'HP')::int * 5)
-                + CEIL((c.stats->>'HP')::numeric * 1.0) * r.cycles,
+                + CEIL((c.stats->>'HP')::numeric * 5 * 0.2) * r.cycles,
                 (c.stats->>'HP')::int * 5
             ),
             last_hp_regen = CASE
                 WHEN LEAST(
                         COALESCE(c.current_hp, (c.stats->>'HP')::int * 5)
-                        + CEIL((c.stats->>'HP')::numeric * 1.0) * r.cycles,
+                        + CEIL((c.stats->>'HP')::numeric * 5 * 0.2) * r.cycles,
                         (c.stats->>'HP')::int * 5
                      ) > COALESCE(c.current_hp, 0)
                 THEN $1


### PR DESCRIPTION
## Summary
- Heal creatures for 20% of their total HP each 12-hour cycle
- Use max HP units to ensure regeneration increments match `current_hp`

## Testing
- `python -m py_compile creature_battler_bot.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b03417551c8328a576e91697faa341