### PR TITLE
Fix passive healing to use max HP

### DIFF
--- a/creature_battler_bot.py
+++ b/creature_battler_bot.py
@@ -674,13 +674,13 @@ async def regenerate_hp():
         UPDATE creatures c
         SET current_hp = LEAST(
                 COALESCE(c.current_hp, (c.stats->>'HP')::int * 5)
-                + CEIL((c.stats->>'HP')::numeric * 1.0) * r.cycles,
+                + CEIL((c.stats->>'HP')::numeric * 5 * 0.33) * r.cycles,
                 (c.stats->>'HP')::int * 5
             ),
             last_hp_regen = CASE
                 WHEN LEAST(
                         COALESCE(c.current_hp, (c.stats->>'HP')::int * 5)
-                        + CEIL((c.stats->>'HP')::numeric * 1.0) * r.cycles,
+                        + CEIL((c.stats->>'HP')::numeric * 5 * 0.33) * r.cycles,
                         (c.stats->>'HP')::int * 5
                      ) > COALESCE(c.current_hp, 0)
                 THEN $1


### PR DESCRIPTION
## Summary
- Heal creatures based on 33% of their maximum HP during passive regeneration

## Testing
- `python -m py_compile creature_battler_bot.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b037be63708328ac33c820b255d9f4