### PR TITLE
Fix leaderboard record when transferring creature ownership

### DIFF
--- a/creature_battler_bot.py
+++ b/creature_battler_bot.py
@@ -3499,6 +3499,17 @@ async def buy(inter: discord.Interaction, creature_name: str):
                 price,
                 c_row["owner_id"],
             )
+            # Transfer leaderboard record ownership to the buyer
+            await conn.execute(
+                "DELETE FROM creature_records WHERE owner_id=$1 AND LOWER(name)=LOWER($2)",
+                inter.user.id,
+                c_row["name"],
+            )
+            await conn.execute(
+                "UPDATE creature_records SET owner_id=$1 WHERE creature_id=$2",
+                inter.user.id,
+                c_row["id"],
+            )
 
     await _ensure_record(inter.user.id, c_row["id"], c_row["name"])
     await inter.response.send_message(


### PR DESCRIPTION
## Summary
- Transfer creature leaderboard records to the buyer when a creature is purchased

## Testing
- `python -m py_compile creature_battler_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68b47aa8d5e883289920f94f739fc624