### PR TITLE
Fix leaderboard record transfer on creature sale

### DIFF
--- a/creature_battler_bot.py
+++ b/creature_battler_bot.py
@@ -3517,9 +3517,16 @@ async def buy(inter: discord.Interaction, creature_name: str):
                 c_row["name"],
             )
             await conn.execute(
-                "UPDATE creature_records SET owner_id=$1 WHERE creature_id=$2",
+                """
+                UPDATE creature_records
+                SET owner_id = $1,
+                    creature_id = $2
+                WHERE owner_id = $3 AND LOWER(name) = LOWER($4)
+                """,
                 inter.user.id,
                 c_row["id"],
+                c_row["owner_id"],
+                c_row["name"],
             )
 
     await _ensure_record(inter.user.id, c_row["id"], c_row["name"])


### PR DESCRIPTION
## Summary
- Ensure buying a creature moves leaderboard record from seller to buyer by updating record using old owner and name

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bade1168748328a09faa356a6b8aef