### PR TITLE
Add season end command with data backup and reset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ apply_*.py
 *.bak
 __pycache__/
 *.pyc
+season_backups/


### PR DESCRIPTION
## Summary
- add reusable helpers to snapshot database tables and write season backup files
- implement an admin-only /seasonend command with confirmation UI that backs up data and resets trainers to starting values
- ensure runtime backups stay out of version control by ignoring the season_backups directory

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68dd12bb52788328a118811d74e29c71